### PR TITLE
* ADD: Added global enable command for the artefact refine so that itcan be properly toggled.

### DIFF
--- a/code/engine.vc2008/xrEngine/xr_ioc_cmd.cpp
+++ b/code/engine.vc2008/xrEngine/xr_ioc_cmd.cpp
@@ -16,7 +16,7 @@ xr_token							vid_bpp_token							[ ]={
 	{ 0,							0											}
 };
 //-----------------------------------------------------------------------
-
+ENGINE_API int g_game_artefact_refine = 0; // SpikensbroR: Artefact refine
 void IConsole_Command::add_to_LRU( shared_str const& arg )
 {
 	if ( arg.size() == 0 || bEmptyArgsHandled )
@@ -722,7 +722,7 @@ void CCC_Register()
 
 	// Render device states
 	CMD4(CCC_Integer,	"r__supersample",		&ps_r__Supersample,			1,		4		);
-
+	CMD4(CCC_Integer, 	"game_artefact_refine", &g_game_artefact_refine, 0, 1); // SpikensbroR: Artefact refine
 
 	CMD3(CCC_Mask,		"rs_v_sync",			&psDeviceFlags,		rsVSync				);
 //	CMD3(CCC_Mask,		"rs_disable_objects_as_crows",&psDeviceFlags,	rsDisableObjectsAsCrows	);

--- a/code/engine.vc2008/xrGame/Artefact.cpp
+++ b/code/engine.vc2008/xrGame/Artefact.cpp
@@ -610,3 +610,23 @@ void CArtefact::OnHiddenItem()
 	SetState(eHidden);
 	SetNextState(eHidden);
 }
+
+// SpikensbroR: Artefact refine
+
+u32 CArtefact::Cost() const
+{
+	if (m_bRefined && g_game_artefact_refine)
+		return m_cost * 2;
+
+	return m_cost;
+}
+
+float CArtefact::Weight() const
+{
+	if (!m_bRefined && g_game_artefact_refine)
+		return m_weight * 10;
+
+	return m_weight;
+}
+
+// -SpikensbroR

--- a/code/engine.vc2008/xrGame/Artefact.h
+++ b/code/engine.vc2008/xrGame/Artefact.h
@@ -38,7 +38,10 @@ public:
 	virtual void					create_physic_shell				();
 
 	virtual CArtefact*				cast_artefact					()		{return this;}
-
+	// SpikensbroR: Artefact refine
+	virtual	u32 					Cost() const;
+	virtual	float 					Weight() const;
+	// -SpikensbroR
 protected:
 	virtual void					UpdateCLChild					()		{};
 	virtual void					CreateArtefactActivation			();

--- a/code/engine.vc2008/xrGame/Inventory.cpp
+++ b/code/engine.vc2008/xrGame/Inventory.cpp
@@ -1008,7 +1008,9 @@ bool CInventory::CanPutInBelt(PIItem pIItem)
 	if(!m_bBeltUseful)					return false;
 	if(!pIItem || !pIItem->Belt())		return false;
 	if(m_belt.size() >= BeltWidth())	return false;
-
+// SpikensbroR: Artefact refine
+	if (!pIItem->GetRefined() && g_game_artefact_refine)
+		return false;
 	return FreeRoom_inBelt(m_belt, pIItem, BeltWidth(), 1);
 }
 //проверяет можем ли поместить вещь в рюкзак,

--- a/code/engine.vc2008/xrGame/inventory_item.cpp
+++ b/code/engine.vc2008/xrGame/inventory_item.cpp
@@ -52,7 +52,7 @@ CInventoryItem::CInventoryItem()
 	m_flags.set			(FCanTrade, m_can_trade);
 	m_flags.set			(FUsingCondition,FALSE);
 	m_fCondition		= 1.0f;
-
+	m_bRefined 			= 0; // SpikensbroR: Artefact refine
 	m_name = m_nameShort = NULL;
 
 	m_ItemCurrPlace.value			= 0;
@@ -299,6 +299,7 @@ BOOL CInventoryItem::net_Spawn			(CSE_Abstract* DC)
 
 	//!!!
 	m_fCondition = pSE_InventoryItem->m_fCondition;
+	m_bRefined 	 = pSE_InventoryItem->m_bRefined; // SpikensbroR: Artefact refine
 	net_Spawn_install_upgrades( pSE_InventoryItem->m_upgrades );
 
 	m_dwItemIndependencyTime		= 0;
@@ -318,7 +319,7 @@ void CInventoryItem::save(NET_Packet &packet)
 {
 	packet.w_u16			(m_ItemCurrPlace.value);
 	packet.w_float			(m_fCondition);
-
+	packet.w_u32			(m_bRefined); // SpikensbroR: Artefact refine
 	if (object().H_Parent()) 
 	{
 		packet.w_u8			(0);
@@ -448,7 +449,7 @@ void CInventoryItem::load(IReader &packet)
 {
 	m_ItemCurrPlace.value	= packet.r_u16();
 	m_fCondition			= packet.r_float();
-
+	m_bRefined 				= packet.r_u32(); // SpikensbroR: Artefact refine
 	u8						tmp = packet.r_u8();
 	if (!tmp)
 		return;

--- a/code/engine.vc2008/xrGame/inventory_item.h
+++ b/code/engine.vc2008/xrGame/inventory_item.h
@@ -14,6 +14,7 @@
 #include "xrserver_objects_alife.h"
 #include "xrserver_objects_alife_items.h"
 
+ENGINE_API int g_game_artefact_refine;
 enum EHandDependence{
 	hdNone	= 0,
 	hd1Hand	= 1,
@@ -159,7 +160,10 @@ public:
 	virtual	float				GetConditionToShow	() const					{return GetCondition();}
 	IC		void				SetCondition		(float val)					{m_fCondition = val;}
 			void				ChangeCondition		(float fDeltaCondition);
-
+			// SpikensbroR: Artefact refine
+	IC 		bool 				GetRefined			() const { return m_bRefined; };
+	IC 		void 				SetRefined			(bool value) { m_bRefined = value; };
+			// -SpikensbroR
 			u16					BaseSlot			()  const					{return m_ItemCurrPlace.base_slot_id;}
 			u16					CurrSlot			()  const					{return m_ItemCurrPlace.slot_id;}
 			u16					CurrPlace			()  const					{return m_ItemCurrPlace.type;}
@@ -181,6 +185,7 @@ protected:
 	u32							m_cost;
 	float						m_weight;
 	float						m_fCondition;
+	u32							m_bRefined; // SpikensbroR: Artefact refine
 	shared_str					m_Description;
 protected:
 	ALife::_TIME_ID				m_dwItemIndependencyTime;

--- a/code/engine.vc2008/xrGame/script_game_object.cpp
+++ b/code/engine.vc2008/xrGame/script_game_object.cpp
@@ -562,3 +562,29 @@ void CScriptGameObject::set_visual_name						(LPCSTR visual)
 LPCSTR CScriptGameObject::get_visual_name				() const {
 	return object().cNameVisual().c_str();
 }
+
+// SpikensbroR: Artefact refine
+bool CScriptGameObject::GetRefined() const
+{
+	CInventoryItem* inventory_item = smart_cast<CInventoryItem*>(&object());
+	if (!inventory_item)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError, "CScriptEntity : cannot access class member GetRefined!");
+		return false;
+	}
+
+	return inventory_item->GetRefined();
+}
+
+void CScriptGameObject::SetRefined(bool value)
+{
+	CInventoryItem* inventory_item = smart_cast<CInventoryItem*>(&object());
+	if (!inventory_item)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError, "CScriptEntity : cannot access class member SetRefined!");
+		return;
+	}
+	
+	inventory_item->SetRefined(value);
+}
+// -SpikensbroR

--- a/code/engine.vc2008/xrGame/script_game_object.h
+++ b/code/engine.vc2008/xrGame/script_game_object.h
@@ -184,7 +184,10 @@ public:
 			u32					Cost				() const;
 			float				GetCondition		() const;
 			void				SetCondition		(float val);
-
+	// SpikensbroR: Artefact refine
+			bool 				GetRefined			() const;
+			void 				SetRefined			(bool value);
+	// -SpikensbroR
 	// CEntity
 	_DECLARE_FUNCTION10	(DeathTime	,	u32		);
 	_DECLARE_FUNCTION10	(MaxHealth	,	float	);

--- a/code/engine.vc2008/xrGame/script_game_object_script2.cpp
+++ b/code/engine.vc2008/xrGame/script_game_object_script2.cpp
@@ -91,6 +91,10 @@ class_<CScriptGameObject> script_register_game_object1(class_<CScriptGameObject>
 		.def("cost",						&CScriptGameObject::Cost)
 		.def("condition",					&CScriptGameObject::GetCondition)
 		.def("set_condition",				&CScriptGameObject::SetCondition)
+		// SpikensbroR: Artefact refine
+		.def("refined", 					&CScriptGameObject::GetRefined)
+		.def("set_refined", 				&CScriptGameObject::SetRefined)
+		// -SpikensbroR
 		.def("death_time",					&CScriptGameObject::DeathTime)
 //		.def("armor",						&CScriptGameObject::Armor)
 		.def("max_health",					&CScriptGameObject::MaxHealth)

--- a/code/engine.vc2008/xrGame/ui/UIActorMenuInventory.cpp
+++ b/code/engine.vc2008/xrGame/ui/UIActorMenuInventory.cpp
@@ -641,7 +641,7 @@ bool CUIActorMenu::ToBelt(CUICellItem* itm, bool b_use_cursor_pos)
 			return false;
 
 		CUICellItem* slot_cell				= belt_list->GetCellAt(belt_cell_pos).m_item;
-
+		if (!slot_cell) return false;
 		bool result							= ToBag(slot_cell, false);
 		VERIFY								(result);
 

--- a/code/engine.vc2008/xrGame/ui/ui_af_params.cpp
+++ b/code/engine.vc2008/xrGame/ui/ui_af_params.cpp
@@ -16,21 +16,24 @@ CUIArtefactParams::CUIArtefactParams()
 {
 	for ( u32 i = 0; i < ALife::infl_max_count; ++i )
 	{
-		m_immunity_item[i] = NULL;
+		m_immunity_item[i] = 0;
 	}
 	for ( u32 i = 0; i < ALife::eRestoreTypeMax; ++i )
 	{
-		m_restore_item[i] = NULL;
+		m_restore_item[i] = 0;
 	}
-	m_additional_weight = NULL;
+	m_additional_weight = 0;
+	m_Prop_line = 0;
+	m_refined = 0; // SpikensbroR: Artefact refine
 }
 
 CUIArtefactParams::~CUIArtefactParams()
 {
-	delete_data	( m_immunity_item );
-	delete_data	( m_restore_item );
-	xr_delete	( m_additional_weight );
-	xr_delete	( m_Prop_line );
+	delete_data	(m_immunity_item );
+	delete_data	(m_restore_item );
+	xr_delete	(m_additional_weight );
+	xr_delete	(m_Prop_line );
+	xr_delete	(m_refined); // SpikensbroR: Artefact refine
 }
 
 LPCSTR af_immunity_section_names[] = // ALife::EInfluenceType
@@ -82,6 +85,15 @@ void CUIArtefactParams::InitFromXml( CUIXml& xml )
 	CUIXmlInit::InitWindow( xml, base, 0, this );
 	xml.SetLocalRoot( base_node );
 	
+	// SpikensbroR: Artefact refine
+	m_refined = xr_new<UIArtefactParamItem>();
+	m_refined->Init(xml, "refined");
+	m_refined->SetAutoDelete(false);
+	name = CStringTable().translate("ui_inv_af_refined").c_str();
+	m_refined->SetCaption(name);
+	xml.SetLocalRoot(base_node);
+	// -SpikensbroR
+ 
 	m_Prop_line = xr_new<CUIStatic>();
 	AttachChild( m_Prop_line );
 	m_Prop_line->SetAutoDelete( false );	
@@ -138,7 +150,18 @@ void CUIArtefactParams::SetInfo( shared_str const& af_section )
 	{
 		return;
 	}
-
+	
+	// SpikensbroR: Artefact refine
+	m_refined->SetText(pInvItem.GetRefined()
+		? CStringTable().translate("ui_inv_af_refined_true").c_str()
+		: CStringTable().translate("ui_inv_af_refined_false").c_str());
+	pos.set(m_refined->GetWndPos());
+	pos.y = h;
+	m_refined->SetWndPos(pos);
+	h += m_refined->GetWndSize().y;
+	AttachChild(m_refined);
+	// -SpikensbroR
+ 
 	float val = 0.0f, max_val = 1.0f;
 	Fvector2 pos;
 	float h = m_Prop_line->GetWndPos().y+m_Prop_line->GetWndSize().y;
@@ -278,5 +301,12 @@ void UIArtefactParamItem::SetValue( float value )
 			m_caption->InitTexture( m_texture_minus.c_str() );
 		}
 	}
-
 }
+
+// SpikensbroR: Artefact refine
+void UIArtefactParamItem::SetText(LPCSTR value)
+{
+	SetValue(0.f);
+	m_value->SetText(value);
+}
+// -SpikensbroR

--- a/code/engine.vc2008/xrGame/ui/ui_af_params.h
+++ b/code/engine.vc2008/xrGame/ui/ui_af_params.h
@@ -20,7 +20,7 @@ protected:
 	UIArtefactParamItem*	m_immunity_item[ALife::infl_max_count];
 	UIArtefactParamItem*	m_restore_item[ALife::eRestoreTypeMax];
 	UIArtefactParamItem*	m_additional_weight;
-
+	UIArtefactParamItem* 	m_refined; // SpikensbroR: Artefact refine
 	CUIStatic*				m_Prop_line;
 
 }; // class CUIArtefactParams
@@ -33,9 +33,10 @@ public:
 				UIArtefactParamItem	();
 	virtual		~UIArtefactParamItem();
 		
-		void	Init				( CUIXml& xml, LPCSTR section );
-		void	SetCaption			( LPCSTR name );
-		void	SetValue			( float value );
+		void	Init				(CUIXml& xml, LPCSTR section);
+		void	SetCaption			(LPCSTR name);
+		void	SetValue			(float value);
+		void 	SetText				(const char* text);
 	
 private:
 	CUIStatic*	m_caption;

--- a/code/engine.vc2008/xrServerEntities/xrServer_Objects_ALife_Items.cpp
+++ b/code/engine.vc2008/xrServerEntities/xrServer_Objects_ALife_Items.cpp
@@ -30,7 +30,7 @@ CSE_ALifeInventoryItem::CSE_ALifeInventoryItem(LPCSTR caSection)
 {
 	//������� ��������� ����
 	m_fCondition				= 1.0f;
-
+	m_bRefined 					= 0;
 	m_fMass						= pSettings->r_float(caSection, "inv_weight");
 	m_dwCost					= pSettings->r_u32(caSection, "cost");
 
@@ -85,10 +85,11 @@ void CSE_ALifeInventoryItem::STATE_Write	(NET_Packet &tNetPacket)
 {
 	tNetPacket.w_float			(m_fCondition);
 	save_data					(m_upgrades, tNetPacket);
+	tNetPacket.w_u32			(m_bRefined); // SpikensbroR: Artefact refine
 	State.position				= base()->o_Position;
 }
 
-void CSE_ALifeInventoryItem::STATE_Read		(NET_Packet &tNetPacket, u16 size)
+void CSE_ALifeInventoryItem::STATE_Read(NET_Packet &tNetPacket, u16 size)
 {
 	u16 m_wVersion = base()->m_wVersion;
 	if (m_wVersion > 52)
@@ -99,6 +100,11 @@ void CSE_ALifeInventoryItem::STATE_Read		(NET_Packet &tNetPacket, u16 size)
 		load_data				(m_upgrades, tNetPacket);
 	}
 
+	// SpikensbroR: Artefact refine
+ 	if (m_wVersion > 127)
+ 		tNetPacket.r_u32		(m_bRefined);
+ 	// -SpikensbroR
+ 
 	State.position				= base()->o_Position;
 }
 

--- a/code/engine.vc2008/xrServerEntities/xrServer_Objects_ALife_Items.h
+++ b/code/engine.vc2008/xrServerEntities/xrServer_Objects_ALife_Items.h
@@ -40,6 +40,7 @@ public:
 public:
 	float							m_fCondition;
 	float							m_fMass;
+	u32 							m_bRefined; // SpikensbroR: Artefact refine
 	u32								m_dwCost;
 	s32								m_iHealthValue;
 	s32								m_iFoodValue;

--- a/code/engine.vc2008/xrServerEntities/xrServer_Objects_ALife_Items_script.cpp
+++ b/code/engine.vc2008/xrServerEntities/xrServer_Objects_ALife_Items_script.cpp
@@ -19,6 +19,7 @@ void CSE_ALifeInventoryItem::script_register(lua_State *L)
 		class_<CSE_ALifeInventoryItem>
 			("cse_alife_inventory_item")
 //			.def(		constructor<LPCSTR>())
+			.def_readwrite("refined", &CSE_ALifeInventoryItem::m_bRefined) // SpikensbroR: Artefact refine
 	];
 }
 


### PR DESCRIPTION
* ADD: Added cost and weight calculations for artefacts in accordance with the artefact refine system.
* ADD: Added exports for artefact refine.
* ADD: Added m_bRefined to inventory item and added UI code for it.
* ADD: Added artefact refine property to inventory item class.
* ADD: Added artefact refine properties to ALife inventory item object.