### PR TITLE
Added rs_psp console command to switch FPS/TPS modes

### DIFF
--- a/code/engine.vc2008/xrGame/console_commands.cpp
+++ b/code/engine.vc2008/xrGame/console_commands.cpp
@@ -247,6 +247,7 @@ void CCC_RegisterCommands()
     CMD3(CCC_Mask, "rs_wip", &psActorFlags, AF_WORKINPROGRESS);
     CMD3(CCC_Mask, "rs_clearskyinterface", &psActorFlags, AF_CLEARSKYINTERFACE);
     CMD3(CCC_Mask, "rs_showdate", &psActorFlags, AF_SHOWDATE);
+	CMD3(CCC_Mask, "rs_psp", &psActorFlags, AF_PSP);
 	CMD1(CCC_TimeFactor, "time_factor");
 	CMD1(CCC_Spawn, "g_spawn");
 	CMD1(CCC_Spawn_to_inventory, "g_spawn_to_inventory");


### PR DESCRIPTION
SoC executable has -psp key to switch in third person shooter mode.
I found this key, and it looks workable as in SoC

__All changes must go ox_dev branch.__

Merge this PR when the following tasks are complete:

- [ ] Pulled branch and ran code locally
- [ ] Appveyor checking 
