### PR TITLE
Костыль против падения ФПС при наличии моба с невалидной позицией

### DIFF
--- a/code/engine.vc2008/xrSound/SoundRender_Emitter.cpp
+++ b/code/engine.vc2008/xrSound/SoundRender_Emitter.cpp
@@ -11,7 +11,7 @@ extern	float			psSoundVEffects;
 
 void CSoundRender_Emitter::set_position(const Fvector &pos)
 {
-	if (source()->channels_num() == 1)
+	if ( source()->channels_num() == 1 && _valid( pos ) )
 		p_source.position = pos;
 	else
 		p_source.position.set(0, 0, 0);


### PR DESCRIPTION
В xrSound такую позицию будем игнорировать, что бы никто не сходил с
ума и не забивал лог ругательствами на неготовность источника.

Взято из
https://github.com/OGSR/OGSR-Engine/commit/080b3f81b5d8d580c5ca4cceb97f020c08ce91c4

__All changes must go ox_dev branch.__

Merge this PR when the following tasks are complete:

- [ ] Pulled branch and ran code locally
- [ ] Appveyor checking 
